### PR TITLE
Unmask prisma client not generated error

### DIFF
--- a/lib/prisma-client-exception.filter.ts
+++ b/lib/prisma-client-exception.filter.ts
@@ -10,7 +10,7 @@ import { Response } from 'express';
  * Error codes definition for Prisma Client (Query Engine)
  * https://www.prisma.io/docs/reference/api-reference/error-reference#prisma-client-query-engine
  */
-@Catch(Prisma.PrismaClientKnownRequestError)
+@Catch(Prisma?.PrismaClientKnownRequestError)
 export class PrismaClientExceptionFilter extends BaseExceptionFilter {
   catch(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
     const ctx = host.switchToHttp();

--- a/schematics/nestjs-prisma/templates/docker/postgresql/docker-compose.yml
+++ b/schematics/nestjs-prisma/templates/docker/postgresql/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - 3000:3000
     depends_on:
-      - postgres
+      - nest-postgres
     env_file:
       - .env
 


### PR DESCRIPTION
When running the project for the first time, with an empty prisma model, the generate command won't do anything at postinstall. So, when attempting to run the nestjs project locally, the following error occurs:

`TypeError: Cannot read property 'PrismaClientKnownRequestError' of undefined`

After the fix, the users can now see the original error:
```
ERROR [ExceptionHandler] @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues
```

Which is a lot better, to let the user know what happened and what to do.