### PR TITLE
fix: compatible with FastifyAdapter

### DIFF
--- a/lib/prisma-client-exception.filter.ts
+++ b/lib/prisma-client-exception.filter.ts
@@ -1,105 +1,90 @@
-import { ArgumentsHost, Catch, HttpStatus } from '@nestjs/common';
+import { ArgumentsHost, Catch, HttpServer, HttpStatus } from '@nestjs/common';
 import { BaseExceptionFilter } from '@nestjs/core';
 import { Prisma } from '@prisma/client';
 import { Response } from 'express';
 
+export type ErrorCodesStatusMapping = {
+  [key: string]: number;
+};
+
 /**
- *
  * {@link PrismaClientExceptionFilter} handling {@link Prisma.PrismaClientKnownRequestError} exceptions.
- *
- * Error codes definition for Prisma Client (Query Engine)
- * https://www.prisma.io/docs/reference/api-reference/error-reference#prisma-client-query-engine
  */
 @Catch(Prisma?.PrismaClientKnownRequestError)
 export class PrismaClientExceptionFilter extends BaseExceptionFilter {
-  catch(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
-    const ctx = host.switchToHttp();
-    const response = ctx.getResponse<Response>();
+  /**
+   * default error codes mapping
+   *
+   * Error codes definition for Prisma Client (Query Engine)
+   * @see https://www.prisma.io/docs/reference/api-reference/error-reference#prisma-client-query-engine
+   */
+  private errorCodesStatusMapping: ErrorCodesStatusMapping = {
+    P2000: HttpStatus.BAD_REQUEST,
+    P2002: HttpStatus.CONFLICT,
+    P2025: HttpStatus.NOT_FOUND,
+  };
 
-    switch (exception.code) {
-      case 'P2000':
-        this.catchValueTooLong(exception, response);
-        break;
-      case 'P2002':
-        this.catchUniqueConstraint(exception, response);
-        break;
-      case 'P2025':
-        this.catchNotFound(exception, response);
-        break;
-      default:
-        this.unhandledException(exception, host);
-        break;
+  /**
+   * @param applicationRef
+   * @param errorCodesStatusMapping
+   */
+  constructor(
+    applicationRef?: HttpServer,
+    errorCodesStatusMapping: ErrorCodesStatusMapping = null,
+  ) {
+    super(applicationRef);
+
+    // use custom error codes mapping (overwrite)
+    //
+    // @example:
+    //
+    //   const { httpAdapter } = app.get(HttpAdapterHost);
+    //   app.useGlobalFilters(new PrismaClientExceptionFilter(httpAdapter, {
+    //     P2022: HttpStatus.BAD_REQUEST,
+    //   }));
+    //
+    if (errorCodesStatusMapping) {
+      this.errorCodesStatusMapping = Object.assign(
+        this.errorCodesStatusMapping,
+        errorCodesStatusMapping,
+      );
     }
   }
 
   /**
-   * Catches P2000 error code
-   * https://www.prisma.io/docs/reference/api-reference/error-reference#p2000
-   *
-   * @param exception P2000
-   * @param response 400 Bad Request
-   */
-  catchValueTooLong(
-    exception: Prisma.PrismaClientKnownRequestError,
-    response: Response,
-  ) {
-    const status = HttpStatus.BAD_REQUEST;
-    response.status(status).json({
-      statusCode: status,
-      message: this.cleanUpException(exception),
-    });
-  }
-
-  /**
-   * Catches P2002 error code
-   * https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
-   *
-   * @param exception P2002
-   * @param response 409 Conflict
-   */
-  catchUniqueConstraint(
-    exception: Prisma.PrismaClientKnownRequestError,
-    response: Response,
-  ) {
-    const status = HttpStatus.CONFLICT;
-    response.status(status).json({
-      statusCode: status,
-      message: this.cleanUpException(exception),
-    });
-  }
-
-  /**
-   * Catches P2025 error code
-   * https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
-   *
-   * @param exception P2025
-   * @param response 404 Not Found
-   */
-  catchNotFound(
-    exception: Prisma.PrismaClientKnownRequestError,
-    response: Response,
-  ) {
-    const status = HttpStatus.NOT_FOUND;
-    response.status(status).json({
-      statusCode: status,
-      message: this.cleanUpException(exception),
-    });
-  }
-
-  unhandledException(
-    exception: Prisma.PrismaClientKnownRequestError,
-    host: ArgumentsHost,
-  ) {
-    // default 500 error code
-    super.catch(exception, host);
-  }
-
-  /**
-   *
    * @param exception
-   * @returns replace line breaks with empty string
+   * @param host
+   * @returns
    */
-  cleanUpException(exception: Prisma.PrismaClientKnownRequestError): string {
-    return exception.message.replace(/\n/g, '');
+  catch(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    if (!Object.keys(this.errorCodesStatusMapping).includes(exception.code)) {
+      return super.catch(exception, host);
+    }
+
+    const statusCode = this.errorCodesStatusMapping[exception.code];
+    const message =
+      `[${exception.code}]: ` + this.exceptionShortMessage(exception.message);
+
+    response.status(statusCode).send(
+      JSON.stringify({
+        statusCode,
+        message,
+      }),
+    );
+  }
+
+  /**
+   * @param exception
+   * @returns
+   */
+  exceptionShortMessage(message: string): string {
+    const shortMessage = message.substring(message.indexOf('→'));
+    return shortMessage
+      .substring(shortMessage.indexOf('\n'))
+      .replace(/\n/g, '')
+      .trim();
   }
 }


### PR DESCRIPTION
1. use `response.status(...).send()` instead of `response.status(...).json()` for compatible with FastifyAdapter. (#20)
2. add custom errorCodesStatusMapping for more diff prisma query engine error code.