### PR TITLE
Simplify error handling flow

### DIFF
--- a/lib/prisma-client-exception.filter.ts
+++ b/lib/prisma-client-exception.filter.ts
@@ -82,7 +82,7 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
       `[${exception.code}]: ` + this.exceptionShortMessage(exception.message);
 
     if (!Object.keys(this.errorCodesStatusMapping).includes(exception.code)) {
-      throw exception;
+      return super.catch(exception, host);
     }
 
     super.catch(new HttpException({ statusCode, message }, statusCode), host);

--- a/lib/prisma-client-exception.filter.ts
+++ b/lib/prisma-client-exception.filter.ts
@@ -85,7 +85,7 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
       throw exception;
     }
 
-    throw new HttpException({ statusCode, message }, statusCode);
+    super.catch(new HttpException({ statusCode, message }, statusCode), host);
   }
 
   private catchNotFoundError(
@@ -94,7 +94,7 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
   ) {
     const statusCode = HttpStatus.NOT_FOUND;
 
-    throw new HttpException({ statusCode, message }, statusCode);
+    super.catch(new HttpException({ statusCode, message }, statusCode), host);
   }
 
   exceptionShortMessage(message: string): string {


### PR DESCRIPTION
Fixes #38 

It maybe naive, but it should be enough to just throw a new error instead, right? Other exception filters will catch it and wrap it properly?

Or should we return it instead? Couldn't find any info in the [docs](https://docs.nestjs.com/exception-filters)