### PR TITLE
support custom error message mappings

### DIFF
--- a/lib/prisma-client-exception.filter.ts
+++ b/lib/prisma-client-exception.filter.ts
@@ -121,7 +121,7 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
   private defaultStatusCode(
     exception: Prisma.PrismaClientKnownRequestError,
   ): number | undefined {
-    return this.defaultMapping?.[exception.code];
+    return this.defaultMapping[exception.code];
   }
 
   private userDefinedExceptionMessage(


### PR DESCRIPTION
resolves #72

## Examples

### useGlobalFilters()

```ts
// src/main.ts
import { HttpStatus } from '@nestjs/common';
import { HttpAdapterHost, NestFactory } from '@nestjs/core';
import { PrismaClientExceptionFilter } from 'nestjs-prisma';
import { AppModule } from './app.module';

async function bootstrap() {
  const app = await NestFactory.create(AppModule);

  // prisma exception filter
  const { httpAdapter } = app.get(HttpAdapterHost);
  app.useGlobalFilters(
    new PrismaClientExceptionFilter(
      httpAdapter,
      // Prisma Error Code: HTTP Status Response
      {
        P2000: HttpStatus.BAD_REQUEST,
        P2002: HttpStatus.CONFLICT,
        P2025: HttpStatus.NOT_FOUND,
      },
      // Prisma Error Code: Error Message
      // You can omit some error codes (like P2002 here) so that the default messages are used.
      {
        P2000: 'something went wrong',
        P2025: 'resource not found',
      },
    ),
  );

  await app.listen(3000);
}
bootstrap();
```

### APP_FILTER

```ts
// src/app.module.ts
import { HttpStatus, Module } from '@nestjs/common';
import { AppController } from './app.controller';
import { AppService } from './app.service';
import { APP_FILTER, HttpAdapterHost } from '@nestjs/core';
import { PrismaClientExceptionFilter, PrismaModule } from 'nestjs-prisma';

@Module({
  imports: [PrismaModule.forRoot()],
  controllers: [AppController],
  providers: [
    AppService,
    {
      provide: APP_FILTER,
      useFactory: ({ httpAdapter }: HttpAdapterHost) => {
        return new PrismaClientExceptionFilter(
          httpAdapter,
          {
            // Prisma Error Code: HTTP Status Response
            P2000: HttpStatus.BAD_REQUEST,
            P2002: HttpStatus.CONFLICT,
            P2025: HttpStatus.NOT_FOUND,
          },
          // Prisma Error Code: Error Message
          // You can omit some error codes (like P2002 here) so that the default messages are used.
          {
            P2000: 'something went wrong',
            P2025: 'resource not found',
          },
        );
      },
      inject: [HttpAdapterHost],
    },
  ],
})
export class AppModule {}
```

or

```ts
// src/app.module.ts
import { HttpStatus, Module } from '@nestjs/common';
import { AppController } from './app.controller';
import { AppService } from './app.service';
import {
  PrismaModule,
  providePrismaClientExceptionFilter,
} from 'nestjs-prisma';

@Module({
  imports: [PrismaModule.forRoot()],
  controllers: [AppController],
  providers: [
    AppService,
    providePrismaClientExceptionFilter(
      {
        P2000: HttpStatus.BAD_REQUEST,
        P2002: HttpStatus.CONFLICT,
        P2025: HttpStatus.NOT_FOUND,
      },
      {
        P2000: 'something went wrong',
        P2025: 'resource not found',
      },
    ),
  ],
})
export class AppModule {}
```

## Results

### Before

![image](https://github.com/notiz-dev/nestjs-prisma/assets/8451003/ac29f5e7-03ee-40cd-a5fc-87a61b0dc0e2)

### After

![image](https://github.com/notiz-dev/nestjs-prisma/assets/8451003/4586fbf9-c2ba-4017-97ac-4eef621664b2)

## Note

Only status mappings are used for judging whether or not to handle Prisma errors. Message mappings are not used for it. So if the app setting is like this:

```ts
      // status mappings
      {
        P2000: HttpStatus.BAD_REQUEST,
      },
      // message mappings
      {
        P2000: 'something went wrong',
        P2028: 'transaction error',
      },
```

the nest app returns `500 Internal server error` when `P2028` happens. Note that `P2000` `P2002` `P2025` are always handled implicitly because they are hard-coded.