### PR TITLE
refactor docs

### DIFF
--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -124,6 +124,7 @@ Alternatively, you can use a class instead of a factory:
 
 ```ts
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { PrismaModule } from 'nestjs-prisma';
 
 @Module({

--- a/docs/src/content/docs/exception-filter.md
+++ b/docs/src/content/docs/exception-filter.md
@@ -127,7 +127,20 @@ import { PrismaClientExceptionFilter } from 'nestjs-prisma';
       },
       inject: [HttpAdapterHost],
     },
-    // or
+  ],
+})
+export class AppModule {}
+```
+
+Or use `providePrismaClientExceptionFilter()` (available since `v0.21.0-dev.0`)
+
+```ts
+//src/app.module.ts
+import { HttpStatus, Module } from '@nestjs/common';
+import { providePrismaClientExceptionFilter } from 'nestjs-prisma';
+
+@Module({
+  providers: [
     providePrismaClientExceptionFilter({
       // Prisma Error Code: HTTP Status Response
       P2000: HttpStatus.BAD_REQUEST,

--- a/docs/src/content/docs/exception-filter.md
+++ b/docs/src/content/docs/exception-filter.md
@@ -22,7 +22,6 @@ Instantiate the filter in your `main.ts` and pass the `HttpAdapterHost`
 
 ```ts
 //src/main.ts
-import { ValidationPipe } from '@nestjs/common';
 import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { PrismaClientExceptionFilter } from 'nestjs-prisma';
@@ -67,7 +66,6 @@ Or use `providePrismaClientExceptionFilter()` (available since `v0.21.0-dev.0`)
 ```ts
 //src/app.module.ts
 import { Module } from '@nestjs/common';
-import { APP_FILTER, HttpAdapterHost } from '@nestjs/core';
 import { providePrismaClientExceptionFilter } from 'nestjs-prisma';
 
 @Module({
@@ -84,7 +82,7 @@ Provide your own error code mapping, if you like to catch additional [Prisma Cli
 
 ```ts
 //src/main.ts
-import { ValidationPipe } from '@nestjs/common';
+import { HttpStatus } from '@nestjs/common';
 import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { PrismaClientExceptionFilter } from 'nestjs-prisma';
@@ -111,7 +109,7 @@ bootstrap();
 
 ```ts
 //src/app.module.ts
-import { Module } from '@nestjs/common';
+import { HttpStatus, Module } from '@nestjs/common';
 import { APP_FILTER, HttpAdapterHost } from '@nestjs/core';
 import { PrismaClientExceptionFilter } from 'nestjs-prisma';
 

--- a/docs/src/content/docs/logging-middleware.md
+++ b/docs/src/content/docs/logging-middleware.md
@@ -69,6 +69,7 @@ Change the log level from your `.env` file using the [@nestjs/config](https://do
 
 ```ts
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { PrismaModule, loggingMiddleware, QueryInfo } from 'nestjs-prisma';
 
 @Module({


### PR DESCRIPTION
Hi, reading the docs I've found some code blocks with missing and unused imports. So, I fixed them.
Also in the example of [Exception Filter > Error code mapping > APP_FILTER](https://nestjs-prisma.dev/docs/exception-filter/#app_filter-1) there is an "or-logic" about using `PrismaClientExceptionFilter` or `providePrismaClientExceptionFilter`. In my opinion, these should be two distincs examples as [above](https://nestjs-prisma.dev/docs/exception-filter/#app_filter).